### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # MeowField AutoPiano v1.0.2 依赖包
 # 核心依赖
-tkinter  # Python内置，无需安装
+#tkinter  # Python内置，无需安装
 pillow>=9.0.0  # 图像处理
 ttkbootstrap>=1.10.0  # 现代化主题
 


### PR DESCRIPTION
注释掉tkinter，不然用requirements.txt安装依赖会报错

```bash
PS D:\Users\Downloads\Compressed\MeowField_AutoPiano-main> pip install -r requirements.txt -i https://pypi.tuna.tsinghua.edu.cn/simple
Looking in indexes: https://pypi.tuna.tsinghua.edu.cn/simple
ERROR: Could not find a version that satisfies the requirement tkinter (from versions: none)
ERROR: No matching distribution found for tkinter
```